### PR TITLE
Update aerospike.template.conf

### DIFF
--- a/configs/aerospike.template.conf
+++ b/configs/aerospike.template.conf
@@ -56,10 +56,6 @@ network {
 		port ${FABRIC_PORT}
 	}
 
-	info {
-	    address ${INFO_ADDRESS}
-		port ${INFO_PORT}
-	}
 }
 
 namespace ${NAMESPACE} {


### PR DESCRIPTION
I figured out that when you updated aerospike-enterprise-server you should forgot to update aerospike template config. 
When I removed info port the pod trigged up successfully and now it's up and running. With that "info" port erros appears with:
 link eth0 state up                                                                                                                                                                                                                       │
│ link eth0 state up in 0                                                                                                                                                                                                                  │
│ Jun 17 2021 13:35:05 GMT: CRITICAL (config): (cfg.c:1626) line 64 :: port must specify an integer value                                                                                                                                  │
│ Jun 17 2021 13:35:05 GMT: WARNING (as): (signal.c:166) SIGINT received, shutting down Aerospike Enterprise Edition build 5.6.0.5 os debian10                                                                                             │
│ Jun 17 2021 13:35:05 GMT: WARNING (as): (signal.c:169) startup was not complete, exiting immediately