### PR TITLE
Allow name overrides

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -3,14 +3,23 @@
 Define aerospike.name
 */}}
 {{- define "aerospike.name" -}}
-{{- default .Chart.Name -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Define aerospike.fullname
 */}}
 {{- define "aerospike.fullname" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Wondered if you folks would be interested in allowing name overrides for chart.  Currently didn't see a good way to control the svc name, it had been removed in a previous commit.  This pattern was taken from [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common)