### PR TITLE
Remove rest client from aerospike kuberenetes enterprise

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -209,20 +209,6 @@ entries:
     urls:
     - https://aerospike.github.io/aerospike-kubernetes-enterprise/aerospike-enterprise-4.6.0.tgz
     version: 4.6.0
-  aerospike-rest-client:
-  - apiVersion: v2
-    appVersion: 1.6.0
-    created: "2020-07-21T11:51:03.730512+05:30"
-    description: Helm Chart For Aerospike REST Client On Kubernetes
-    digest: 77887e205164a6fbde1b51cd7f16f125774fefb024d8b7b87bc6a87e72dbfa12
-    icon: https://avatars0.githubusercontent.com/u/2214313?s=200&v=4
-    name: aerospike-rest-client
-    sources:
-    - https://github.com/aerospike/aerospike-client-rest-kubernetes
-    type: application
-    urls:
-    - https://aerospike.github.io/aerospike-client-rest-kubernetes/aerospike-rest-client-0.1.0.tgz
-    version: 0.1.0
   aerospike-backup:
     - apiVersion: v2
       appVersion: 3.4.0


### PR DESCRIPTION
Has not been updated in some time. Removing.